### PR TITLE
Update schema.ts, switched from includes() to items()

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -31,9 +31,9 @@ export var repository = Joi.object({
 
 export var header = Joi.object({
 	label: label.required(),
-	project: Joi.array().min(1).includes(project).required(),
+	project: Joi.array().min(1).items(project).required(),
 	repository: repository.required(),
-	authors: Joi.array().min(1).includes(person).required()
+	authors: Joi.array().min(1).items(person).required()
 }).description('definition-header').options({
 	allowUnknown: true,
 	stripUnknown: true,


### PR DESCRIPTION
As per issue hapijs/joi#554 and the commit closing/solving it hapijs/joi@02d65818b98998b49f8d22c820239d428a624ed4 array().includes() has been moved to array.items() Just fixing that particular case inside schema.ts (not sure if there are more broken lines out there)
